### PR TITLE
Mount local folder for routing results

### DIFF
--- a/dkroutingtool/local_start.sh
+++ b/dkroutingtool/local_start.sh
@@ -1,6 +1,7 @@
 docker run -it \
   --mount src=`pwd`/src,target=/src,type=bind \
   --mount src=`pwd`/scripts,target=/scripts,type=bind \
+  --mount src=`pwd`/../working_data_dir,target=/WORKING_DATA_DIR,type=bind \
   -p 8080:8080 \
   -p 5001:5001 \
   dkroutingtool:dev bash


### PR DESCRIPTION
Update the local_start.sh to have a local mount `working_data_dir` at the same level as the `Sample Brooklyn Output` folder. This way, routing outputs are placed on the host at the time of generation and copying them outside the container isn't necessary.

This may not be a great idea, however, depending on what the intended use for `working_data_dir` (I'm not totally clear on all the uses or potential future uses for the folder). Could also cause unexpected behavior on subsequent runs if `working_data_dir` is not empty.